### PR TITLE
Fixed typescript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,7 @@ declare namespace RModal {
 }
 
 declare class RModal {
-    constructor(el: HTMLElement, opts?: RModalOptions);
+    constructor(el: HTMLElement, opts?: RModal.RModalOptions);
     version: string;
     close(): void;
     content(content?: string): string | void;


### PR DESCRIPTION
Without specifying namespace for RModalOptions, typescript shows opts in RModal constructor as any, thus no intellisense is provided.