### PR TITLE
Add missing afterOpen and beforeClose options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,8 @@
 declare namespace RModal {
     export interface RModalOptions {
         afterClose?(): void;
+        afterOpen?(): void;
+        beforeClose?(callback: Function): void;
         beforeOpen?(callback: Function): void;
         bodyClass?: string;
         closeTimeout?: number;


### PR DESCRIPTION
Some options was missing in the TypeScript definition. I added these.